### PR TITLE
Add rule state (active, inactive) to Parse::Snort

### DIFF
--- a/lib/Parse/Snort.pm
+++ b/lib/Parse/Snort.pm
@@ -150,6 +150,15 @@ sub parse {
     $rule =~ s/^\s+//;
     $rule =~ s/\s+$//;
 
+    # Rules are distributed without being enabled
+    if ($rule =~ /^#/) {
+        $rule =~ s/^#+\s*//g;
+        $self->state(0);
+    }
+    else {
+        $self->state(1);
+    }
+
     # 20090823 RGH: m/\s+/ instead of m/ /; bug reported by Leon Ward
     my @values = split( m/\s+/, $rule, scalar @RULE_ELEMENTS );    # no critic
 
@@ -160,6 +169,21 @@ sub parse {
 }
 
 =back
+
+=head2 state
+
+The state of the rule: active (1) or commented (0)
+
+=cut
+
+sub state {
+    my ($self, $state) = @_;
+
+    if (defined $state) {
+        $self->{state} = $state;
+    }
+    return $self->{state} // 1;
+}
 
 =head2 METHODS FOR ACCESSING RULE ELEMENTS
 
@@ -379,6 +403,8 @@ sub references {
 
 The C<as_string> method returns a string that matches the normal Snort rule form of the object.  This is what you want to use to write a rule to an output file that will be read by Snort.
 
+=back
+
 =cut
 
 sub as_string {
@@ -398,10 +424,9 @@ sub as_string {
     { $ret .= sprintf( " (%s)", join( " ", map { defined($_->[1]) ? "$_->[0]:$_->[1];" : "$_->[0];" } @{ $self->get('opts') } )); }
 
     #carp sprintf( "Missing required rule element(s): %s", join( " ", @missing )) if (scalar @missing);
-    return ! scalar @missing ? $ret : undef;
+    return undef if @missing;
+    return $self->state ? $ret : "# $ret";
 }
-
-=back
 
 =head1 AUTHOR
 

--- a/t/10_parse_text_rule.t
+++ b/t/10_parse_text_rule.t
@@ -1,48 +1,80 @@
-#!perl -T
+use strict;
+use warnings;
 
-use Test::More qw(no_plan);
+use Test::More;
+use Parse::Snort;
 
-BEGIN {
-	use_ok( 'Parse::Snort' );
-}
-
-my $text_rule = 'alert tcp $EXTERNAL_NET $HTTP_PORTS -> $HOME_NET any (msg:"WEB-CLIENT Windows Scripting Host Shell ActiveX CLSID access"; flow:established,to_client; content:"F935DC22-1CF0-11D0-ADB9-00C04FD58A0B"; nocase; pcre:"/<OBJECT\s+[^>]*classid\s*=\s*[\x22\x27]?\s*clsid\s*\x3a\s*\x7B?\s*F935DC22-1CF0-11D0-ADB9-00C04FD58A0B/si"; reference:bugtraq,1399; reference:bugtraq,1754; reference:bugtraq,598; reference:bugtraq,8456; reference:cve,1999-0668; reference:cve,2000-0597; reference:cve,2000-1061; reference:cve,2003-0532; reference:url,support.microsoft.com/default.aspx?scid=kb\;en-us\;Q240308; reference:url,www.microsoft.com/technet/security/bulletin/MS00-049.mspx; reference:url,www.microsoft.com/technet/security/bulletin/MS00-075.mspx; reference:url,www.microsoft.com/technet/security/bulletin/MS03-032.mspx; reference:url,www.microsoft.com/technet/security/bulletin/MS99-032.mspx; classtype:attempted-user; sid:8066; rev:1;)';
+my $text_rule
+    = 'alert tcp $EXTERNAL_NET $HTTP_PORTS -> $HOME_NET any (msg:"WEB-CLIENT Windows Scripting Host Shell ActiveX CLSID access"; flow:established,to_client; content:"F935DC22-1CF0-11D0-ADB9-00C04FD58A0B"; nocase; pcre:"/<OBJECT\s+[^>]*classid\s*=\s*[\x22\x27]?\s*clsid\s*\x3a\s*\x7B?\s*F935DC22-1CF0-11D0-ADB9-00C04FD58A0B/si"; reference:bugtraq,1399; reference:bugtraq,1754; reference:bugtraq,598; reference:bugtraq,8456; reference:cve,1999-0668; reference:cve,2000-0597; reference:cve,2000-1061; reference:cve,2003-0532; reference:url,support.microsoft.com/default.aspx?scid=kb\;en-us\;Q240308; reference:url,www.microsoft.com/technet/security/bulletin/MS00-049.mspx; reference:url,www.microsoft.com/technet/security/bulletin/MS00-075.mspx; reference:url,www.microsoft.com/technet/security/bulletin/MS03-032.mspx; reference:url,www.microsoft.com/technet/security/bulletin/MS99-032.mspx; classtype:attempted-user; sid:8066; rev:1;)';
 
 my $rule_data = {
-                     'src_port' => '$HTTP_PORTS',
-                     'proto' => 'tcp',
-                     'src' => '$EXTERNAL_NET',
-                     'dst_port' => 'any',
-                     'direction' => '->',
-                     'action' => 'alert',
-                     'opts' => [
-                                 [ 'msg', '"WEB-CLIENT Windows Scripting Host Shell ActiveX CLSID access"' ],
-                                 [ 'flow', 'established,to_client' ],
-                                 [ 'content', '"F935DC22-1CF0-11D0-ADB9-00C04FD58A0B"' ],
-                                 [ 'nocase' ],
-                                 [ 'pcre', '"/<OBJECT\\s+[^>]*classid\\s*=\\s*[\\x22\\x27]?\\s*clsid\\s*\\x3a\\s*\\x7B?\\s*F935DC22-1CF0-11D0-ADB9-00C04FD58A0B/si"' ],
-                                 [ 'reference', 'bugtraq,1399' ],
-                                 [ 'reference', 'bugtraq,1754' ],
-                                 [ 'reference', 'bugtraq,598' ],
-                                 [ 'reference', 'bugtraq,8456' ],
-                                 [ 'reference', 'cve,1999-0668' ],
-                                 [ 'reference', 'cve,2000-0597' ],
-                                 [ 'reference', 'cve,2000-1061' ],
-                                 [ 'reference', 'cve,2003-0532' ],
-                                 [ 'reference', 'url,support.microsoft.com/default.aspx?scid=kb\\;en-us\\;Q240308' ],
-                                 [ 'reference', 'url,www.microsoft.com/technet/security/bulletin/MS00-049.mspx' ],
-                                 [ 'reference', 'url,www.microsoft.com/technet/security/bulletin/MS00-075.mspx' ],
-                                 [ 'reference', 'url,www.microsoft.com/technet/security/bulletin/MS03-032.mspx' ],
-                                 [ 'reference', 'url,www.microsoft.com/technet/security/bulletin/MS99-032.mspx' ],
-                                 [ 'classtype', 'attempted-user' ],
-                                 [ 'sid', '8066' ],
-                                 [ 'rev', '1' ]
-                               ],
-                     'dst' => '$HOME_NET',
+    'src_port'  => '$HTTP_PORTS',
+    'proto'     => 'tcp',
+    'src'       => '$EXTERNAL_NET',
+    'dst_port'  => 'any',
+    'direction' => '->',
+    'action'    => 'alert',
+    'opts'      => [
+        [
+            'msg',
+            '"WEB-CLIENT Windows Scripting Host Shell ActiveX CLSID access"'
+        ],
+        ['flow',    'established,to_client'],
+        ['content', '"F935DC22-1CF0-11D0-ADB9-00C04FD58A0B"'],
+        ['nocase'],
+        [
+            'pcre',
+            '"/<OBJECT\\s+[^>]*classid\\s*=\\s*[\\x22\\x27]?\\s*clsid\\s*\\x3a\\s*\\x7B?\\s*F935DC22-1CF0-11D0-ADB9-00C04FD58A0B/si"'
+        ],
+        ['reference', 'bugtraq,1399'],
+        ['reference', 'bugtraq,1754'],
+        ['reference', 'bugtraq,598'],
+        ['reference', 'bugtraq,8456'],
+        ['reference', 'cve,1999-0668'],
+        ['reference', 'cve,2000-0597'],
+        ['reference', 'cve,2000-1061'],
+        ['reference', 'cve,2003-0532'],
+        [
+            'reference',
+            'url,support.microsoft.com/default.aspx?scid=kb\\;en-us\\;Q240308'
+        ],
+        [
+            'reference',
+            'url,www.microsoft.com/technet/security/bulletin/MS00-049.mspx'
+        ],
+        [
+            'reference',
+            'url,www.microsoft.com/technet/security/bulletin/MS00-075.mspx'
+        ],
+        [
+            'reference',
+            'url,www.microsoft.com/technet/security/bulletin/MS03-032.mspx'
+        ],
+        [
+            'reference',
+            'url,www.microsoft.com/technet/security/bulletin/MS99-032.mspx'
+        ],
+        ['classtype', 'attempted-user'],
+        ['sid',       '8066'],
+        ['rev',       '1']
+    ],
+    'dst' => '$HOME_NET',
+    'state' => 1,
 };
 
 
 my $obj_1 = Parse::Snort->new();
 $obj_1->parse($text_rule);
-is_deeply($obj_1,$rule_data,"parse text rule");
+is_deeply($obj_1, $rule_data, "parse text rule");
 
+my $disabled = "# ". $obj_1->as_string;
+
+$obj_1->state(0);
+
+is($obj_1->as_string, $disabled, "Rule state changed to disabled");
+
+my $obj_2 = Parse::Snort->new();
+$obj_2->parse($disabled);
+is_deeply($obj_1, $obj_2, "Rules are the same");
+
+done_testing();

--- a/t/90_parse_text_rule_abuse.t
+++ b/t/90_parse_text_rule_abuse.t
@@ -1,11 +1,10 @@
-#!perl -T
+use strict;
+use warnings;
 
-use Test::More qw(no_plan);
+use Test::More;
 use Data::Dumper;
 
-BEGIN {
-	use_ok( 'Parse::Snort' );
-}
+use Parse::Snort;
 
 my $text_rule_abuse = '    alert    tcp     $EXTERNAL_NET   $HTTP_PORTS    ->   $HOME_NET    any   ( msg : "WEB-CLIENT Windows Scripting Host Shell ActiveX CLSID access"  ;     flow : established,to_client;   content:"F935DC22-1CF0-11D0-ADB9-00C04FD58A0B";  nocase ;pcre:"/<OBJECT\s+[^>]*classid\s*=\s*[\x22\x27]?\s*clsid\s*\x3a\s*\x7B?\s*F935DC22-1CF0-11D0-ADB9-00C04FD58A0B/si";reference:bugtraq,1399 ; )  ';
 
@@ -41,9 +40,12 @@ my $text_rule_data = {
                                 'bugtraq,1399'
                               ]
                             ],
-                  'dst' => '$HOME_NET'
+                  'dst' => '$HOME_NET',
+                  'state' => 1,
                 };
 
 my $obj_1 = Parse::Snort->new($text_rule_abuse);
 
 is_deeply($obj_1,$text_rule_data,"parse whitespace abusive text rule");
+
+done_testing;


### PR DESCRIPTION
If you try to parse a whole set of rules they often have are commented
out (e.g. via Pulledpork). If Parse::Snort can deal with this you can
actually ask the rule what the state is (active or not) and stringify it
if needed.

